### PR TITLE
lib: node.js v8 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function reload(name) {
 function unload(module) {
     var path = require.resolve(module);
 
-    if (require.cache.hasOwnProperty(path) && require.cache[path].children) {
+    if (require.cache[path] && require.cache[path].children) {
         require.cache[path].children.forEach(function (child) {
             unload(child.id);
         });


### PR DESCRIPTION
`require.cache` is created with `Object.create(null)` in node.js v8, and
thus has no `hasOwnProperty` method anymore.